### PR TITLE
Upgrade org.elasticsearch.client to v7.13.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 		<!-- Test Dependencies -->
 		<commons-io.version>2.5</commons-io.version>
 
-		<elastic.version>7.9.1</elastic.version>
+		<elastic.version>7.13.3</elastic.version>
 
 		<lombok.version>1.16.20</lombok.version>
 


### PR DESCRIPTION
To address vulnerabilities in Elasticsearch as detailed in https://increff.atlassian.net/browse/COMMONS-74, the version of elastic-search must be upgraded to v7.13.3 (earliest non-vulnerable version as per https://sbom.lift.sonatype.com/report/T1-0ff0976f7f21c391f20f-148519095f7b1d-1641366981-a402e097394e4b70880a5277ee35687c